### PR TITLE
Enable profiling for messenger consume command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/MessengerProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/MessengerProfilerListener.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Debug\VirtualRequestStack;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\Messenger\Debug\MessageProcessingRequest;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\EventListener\MessageProfilerListener;
+
+use function spl_object_id;
+
+/**
+ * @internal
+ */
+final class MessengerProfilerListener implements EventSubscriberInterface
+{
+    /** @var array<int, MessageProcessingRequest> */
+    private array $requests = [];
+    /** @var \SplObjectStorage<Request, \Symfony\Component\HttpKernel\Profiler\Profile> */
+    private \SplObjectStorage $profiles;
+    /** @var \SplObjectStorage<Request, ?Request> */
+    private \SplObjectStorage $parents;
+    /** @var array<int, Profile> */
+    private array $savedProfiles = [];
+
+    public function __construct(
+        private readonly Profiler $profiler,
+        private readonly VirtualRequestStack $requestStack,
+        private readonly MessageProfilerListener $messageProfiler,
+    ) {
+        $this->profiles = new \SplObjectStorage();
+        $this->parents = new \SplObjectStorage();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageReceivedEvent::class => ['initialize', -4096],
+            WorkerMessageHandledEvent::class => ['onMessageHandled', -4096],
+            WorkerMessageFailedEvent::class => ['onMessageFailed', -4096],
+        ];
+    }
+
+    public function initialize(WorkerMessageReceivedEvent $event): void
+    {
+        if (!$event->shouldHandle() || !$this->profiler->isEnabled()) {
+            return;
+        }
+
+        $message = $event->getEnvelope()->getMessage();
+        $hash = spl_object_id($message);
+
+        if (isset($this->requests[$hash])) {
+            return;
+        }
+
+        $parentRequest = $this->requestStack->getCurrentRequest();
+        $request = new MessageProcessingRequest($event->getEnvelope(), $event->getReceiverName());
+
+        if (null !== $sectionId = $this->messageProfiler->getSectionId($message)) {
+            $request->attributes->set('_stopwatch_token', $sectionId);
+        }
+
+        $this->requests[$hash] = $request;
+        $this->parents[$request] = $parentRequest;
+        $this->requestStack->push($request);
+    }
+
+    public function onMessageHandled(WorkerMessageHandledEvent $event): void
+    {
+        $this->collect($event->getEnvelope()->getMessage(), true, false, null);
+    }
+
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        $this->collect($event->getEnvelope()->getMessage(), false, $event->willRetry(), $event->getThrowable());
+    }
+
+    private function collect(object $message, bool $ack, bool $willRetry, ?\Throwable $error): void
+    {
+        $hash = spl_object_id($message);
+
+        if (!isset($this->requests[$hash])) {
+            return;
+        }
+
+        $request = $this->requests[$hash];
+        unset($this->requests[$hash]);
+
+        if ($this->requestStack->getCurrentRequest() === $request) {
+            $this->requestStack->pop();
+        }
+
+        $sectionId = $request->attributes->get('_stopwatch_token');
+        $messageProfile = null !== $sectionId ? $this->messageProfiler->getProfile($sectionId) : null;
+        $request->complete($ack, $willRetry, $error, $messageProfile);
+
+        if (!$this->profiler->isEnabled()) {
+            return;
+        }
+
+        $profile = $this->profiler->collect($request, $request->getResponse(), $error);
+        $this->profiles[$request] = $profile;
+
+        if ($parentRequest = $this->parents[$request]) {
+            return;
+        }
+
+        foreach ($this->profiles as $r) {
+            if (null !== $parent = $this->parents[$r]) {
+                if (isset($this->profiles[$parent])) {
+                    $this->profiles[$parent]->addChild($this->profiles[$r]);
+                }
+            }
+        }
+
+        foreach ($this->profiles as $r) {
+            $profile = $this->profiles[$r];
+            $this->profiler->saveProfile($profile);
+            $this->savedProfiles[] = $profile;
+        }
+
+        $this->profiles = new \SplObjectStorage();
+        $this->parents = new \SplObjectStorage();
+    }
+
+    /**
+     * @return Profile[]
+     */
+    public function consumeProfiles(): array
+    {
+        $profiles = $this->savedProfiles;
+        $this->savedProfiles = [];
+
+        return $profiles;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Messenger/ConsumeMessagesCommandProfiler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Messenger/ConsumeMessagesCommandProfiler.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Messenger;
+
+use Symfony\Bundle\FrameworkBundle\EventListener\MessengerProfilerListener;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\EventListener\MessageProfilerListener;
+use Symfony\Component\Messenger\Worker;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @internal
+ */
+final class ConsumeMessagesCommandProfiler
+{
+    public function __construct(
+        private readonly MessageProfilerListener $messageProfiler,
+        private readonly MessengerProfilerListener $messengerProfiler,
+        private readonly Profiler $profiler,
+        private readonly ?UrlGeneratorInterface $urlGenerator = null,
+    ) {
+    }
+
+    /**
+     * @return array{worker: Worker, onStop?: callable}
+     */
+    public function __invoke(Worker $worker, EventDispatcherInterface $eventDispatcher, InputInterface $input, OutputInterface $output, SymfonyStyle $io): array
+    {
+        $this->profiler->enable();
+
+        $eventDispatcher->addSubscriber($this->messageProfiler);
+        $eventDispatcher->addSubscriber($this->messengerProfiler);
+
+        $io->comment('Profiling enabled: a profiler entry will be created for each handled message.');
+
+        $printProfiles = $this->createPrinter($output);
+
+        $listener = static function () use ($printProfiles) {
+            $printProfiles();
+        };
+
+        $eventDispatcher->addListener(WorkerMessageHandledEvent::class, $listener, -8192);
+        $eventDispatcher->addListener(WorkerMessageFailedEvent::class, $listener, -8192);
+
+        return [
+            'worker' => $worker,
+            'onStop' => static function () use ($printProfiles) {
+                $printProfiles();
+            },
+        ];
+    }
+
+    private function createPrinter(OutputInterface $output): callable
+    {
+        $output = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
+        return function () use ($output) {
+            $profiles = $this->messengerProfiler->consumeProfiles();
+
+            if (!$profiles) {
+                return;
+            }
+
+            foreach ($profiles as $profile) {
+                $token = $profile->getToken();
+
+                if ($this->urlGenerator) {
+                    $url = $this->urlGenerator->generate('_profiler', ['token' => $token], UrlGeneratorInterface::ABSOLUTE_URL);
+                    $output->writeln(sprintf('See messenger profile <href=%s>%s</>', $url, $token));
+                } else {
+                    $output->writeln(sprintf('See messenger profile %s', $token));
+                }
+            }
+        };
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -171,6 +171,7 @@ return static function (ContainerConfigurator $container) {
                 [], // Bus names
                 service('messenger.rate_limiter_locator')->nullOnInvalid(),
                 null,
+                service('messenger.command.consume_messages_profiler')->nullOnInvalid(),
             ])
             ->tag('console.command')
             ->tag('monolog.logger', ['channel' => 'messenger'])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger_debug.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\FrameworkBundle\EventListener\MessengerProfilerListener;
+use Symfony\Bundle\FrameworkBundle\Messenger\ConsumeMessagesCommandProfiler;
 use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
+use Symfony\Component\Messenger\EventListener\MessageProfilerListener;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -20,6 +23,26 @@ return static function (ContainerConfigurator $container) {
                 'template' => '@WebProfiler/Collector/messenger.html.twig',
                 'id' => 'messenger',
                 'priority' => 100,
+            ])
+        ->set('messenger.listener.message_profiler', MessageProfilerListener::class)
+            ->args([
+                service('debug.stopwatch'),
+            ])
+            ->tag('kernel.reset', ['method' => 'reset'])
+
+        ->set('messenger.listener.messenger_profiler', MessengerProfilerListener::class)
+            ->args([
+                service('.lazy_profiler'),
+                service('.virtual_request_stack'),
+                service('messenger.listener.message_profiler'),
+            ])
+
+        ->set('messenger.command.consume_messages_profiler', ConsumeMessagesCommandProfiler::class)
+            ->args([
+                service('messenger.listener.message_profiler'),
+                service('messenger.listener.messenger_profiler'),
+                service('.lazy_profiler'),
+                service('router')->nullOnInvalid(),
             ])
     ;
 };

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -36,6 +36,54 @@
         #collector-content .message-bus .trace li.selected {
             background: var(--highlight-selected-line);
         }
+
+        .message-processing .metrics {
+            margin-bottom: 15px;
+        }
+
+        .message-timeline {
+            border: var(--border);
+            background: var(--base-0);
+            padding: 15px;
+            margin-bottom: 20px;
+            border-radius: var(--border-radius);
+        }
+
+        .message-timeline-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 10px;
+            gap: 10px;
+        }
+
+        .message-timeline .label {
+            margin-left: auto;
+        }
+
+        .message-timeline-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 10px;
+        }
+
+        .message-timeline-table th,
+        .message-timeline-table td {
+            padding: 6px 8px;
+            border-top: var(--border);
+        }
+
+        .message-timeline-table thead th {
+            background: var(--base-1);
+        }
+
+        .message-timeline-table tbody tr:nth-child(even) {
+            background: var(--base-1);
+        }
+
+        .message-processing .empty {
+            margin: 15px 0;
+        }
     </style>
 {% endblock %}
 
@@ -81,10 +129,146 @@
 {% block panel %}
     <h2>Messages</h2>
 
+    {% set processed = collector.processedMessages %}
+
+    {% if processed is not empty %}
+        {% set successful = processed|filter(message => message.status == 'ack') %}
+        {% set retrying = processed|filter(message => message.status == 'retry') %}
+        {% set failed = processed|filter(message => message.status == 'failed') %}
+        {% set failedOrRetry = processed|filter(message => message.status != 'ack') %}
+
+        <div class="message-processing">
+            <h3>Worker processing</h3>
+
+            <div class="metrics">
+                <div class="metric">
+                    <span class="value">{{ processed|length }}</span>
+                    <span class="label">Processed messages</span>
+                </div>
+
+                <div class="metric">
+                    <span class="value">{{ successful|length }}</span>
+                    <span class="label">Acknowledged</span>
+                </div>
+
+                <div class="metric">
+                    <span class="value">{{ retrying|length }}</span>
+                    <span class="label">Scheduled for retry</span>
+                </div>
+
+                <div class="metric">
+                    <span class="value">{{ failed|length }}</span>
+                    <span class="label">Failed</span>
+                </div>
+            </div>
+
+            <div class="sf-tabs message-processing">
+                <div class="tab">
+                    <h3 class="tab-title">Timeline<span class="badge">{{ processed|length }}</span></h3>
+
+                    <div class="tab-content">
+                        {% for message in processed %}
+                            {% set statusClass = {
+                                'ack': 'status-success',
+                                'retry': 'status-warning',
+                                'failed': 'status-error'
+                            }[message.status] %}
+                            {% set statusLabel = {
+                                'ack': 'Acknowledged',
+                                'retry': 'Retry scheduled',
+                                'failed': 'Failed'
+                            }[message.status] %}
+
+                            <div class="message-timeline">
+                                <header class="message-timeline-header">
+                                    <span class="dump-inline">{{ profiler_dump(message.message.type) }}</span>
+                                    <span class="label {{ statusClass }}">{{ statusLabel }}</span>
+                                </header>
+
+                                <div class="metrics">
+                                    <div class="metric">
+                                        <span class="value">{{ message.duration is not null ? '%.2f'|format(message.duration) : 'n/a' }} <span class="unit">ms</span></span>
+                                        <span class="label">Duration</span>
+                                    </div>
+
+                                    <div class="metric">
+                                        <span class="value">{{ message.memory is not null ? '%.2f'|format(message.memory / 1024 / 1024) : 'n/a' }} <span class="unit">MiB</span></span>
+                                        <span class="label">Peak memory</span>
+                                    </div>
+
+                                    <div class="metric">
+                                        <span class="value">{{ message.transport ?? 'n/a' }}</span>
+                                        <span class="label">Transport</span>
+                                    </div>
+                                </div>
+
+                                {% if message.timeline %}
+                                    {% set origin = message.origin ?? 0 %}
+                                    <table class="message-timeline-table">
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">Event</th>
+                                                <th scope="col">Start (ms)</th>
+                                                <th scope="col">Duration (ms)</th>
+                                                <th scope="col">Memory</th>
+                                                <th scope="col">Category</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for event in message.timeline %}
+                                                <tr>
+                                                    <td>{{ event.name }}</td>
+                                                    <td>{{ '%.2f'|format((event.start_time ?? 0) - origin) }}</td>
+                                                    <td>{{ '%.2f'|format(event.duration ?? 0) }}</td>
+                                                    <td>
+                                                        {% if event.memory %}
+                                                            {{ '%.2f'|format(event.memory / 1024 / 1024) }} MiB
+                                                        {% else %}
+                                                            0 B
+                                                        {% endif %}
+                                                    </td>
+                                                    <td>{{ event.category }}</td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                {% else %}
+                                    <p class="text-muted">No stopwatch events have been recorded for this message.</p>
+                                {% endif %}
+                            </div>
+                        {% else %}
+                            <div class="empty">
+                                <p>No messages were processed.</p>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div class="tab">
+                    <h3 class="tab-title">Successful<span class="badge status-success">{{ successful|length }}</span></h3>
+
+                    <div class="tab-content">
+                        {{ _self.render_processed_messages(successful) }}
+                    </div>
+                </div>
+
+                <div class="tab">
+                    <h3 class="tab-title">Failed<span class="badge {{ failedOrRetry ? 'status-error' }}">{{ failedOrRetry|length }}</span></h3>
+
+                    <div class="tab-content">
+                        {{ _self.render_processed_messages(failedOrRetry) }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
     {% if collector.messages is empty %}
+        {% if processed is empty %}
         <div class="empty empty-panel">
             <p>No messages have been collected.</p>
         </div>
+        {% endif %}
     {% elseif 1 == collector.buses|length %}
         <p class="text-muted">Ordered list of dispatched messages across all your buses</p>
         {{ _self.render_bus_messages(collector.messages, true) }}
@@ -212,4 +396,79 @@
         </tbody>
     </table>
     {% endfor %}
+{% endmacro %}
+
+{% macro render_processed_messages(messages) %}
+    {% if messages is empty %}
+        <div class="empty">
+            <p>No messages in this category.</p>
+        </div>
+    {% else %}
+        {% set discr = random() %}
+        {% for message in messages %}
+            <table class="message-item message-processed">
+                <thead>
+                    <tr>
+                        <th colspan="2" class="sf-toggle"
+                            data-toggle-selector="#processed-message-{{ discr }}-{{ loop.index0 }}-details"
+                            data-toggle-initial="{{ loop.first ? 'display' }}"
+                        >
+                            <span class="dump-inline">{{ profiler_dump(message.message.type) }}</span>
+                            {% set statusClass = {
+                                'ack': 'status-success',
+                                'retry': 'status-warning',
+                                'failed': 'status-error'
+                            }[message.status] %}
+                            {% set statusLabel = {
+                                'ack': 'Acknowledged',
+                                'retry': 'Retry scheduled',
+                                'failed': 'Failed'
+                            }[message.status] %}
+                            <span class="label {{ statusClass }}">{{ statusLabel }}</span>
+                            <button class="btn btn-link toggle-button" type="button">
+                                <span class="icon icon-close">{{ source('@WebProfiler/Icon/chevron-down.svg') }}</span>
+                                <span class="icon icon-open">{{ source('@WebProfiler/Icon/chevron-down.svg') }}</span>
+                            </button>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody id="processed-message-{{ discr }}-{{ loop.index0 }}-details" class="sf-toggle-content">
+                    <tr>
+                        <th scope="row" class="font-normal">Transport</th>
+                        <td>{{ message.transport ?? 'n/a' }}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row" class="font-normal">Duration</th>
+                        <td>{{ message.duration is not null ? '%.2f'|format(message.duration) ~ ' ms' : 'n/a' }}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row" class="font-normal">Peak memory</th>
+                        <td>{{ message.memory is not null ? '%.2f'|format(message.memory / 1024 / 1024) ~ ' MiB' : 'n/a' }}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row" class="font-normal">Outcome</th>
+                        <td>
+                            {% if message.status == 'ack' %}
+                                Acknowledged by worker
+                            {% elseif message.status == 'retry' %}
+                                Failure, scheduled for retry
+                            {% else %}
+                                Failed without retry
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row" class="font-normal">Message</th>
+                        <td>{{ profiler_dump(message.message.value, maxDepth: 2) }}</td>
+                    </tr>
+                    {% if message.exception is defined %}
+                        <tr>
+                            <th scope="row" class="font-normal">Exception</th>
+                            <td>{{ profiler_dump(message.exception.value, maxDepth: 1) }}</td>
+                        </tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        {% endfor %}
+    {% endif %}
 {% endmacro %}

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -47,6 +47,11 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
     private ?Worker $worker = null;
 
+    /**
+     * @var callable|null
+     */
+    private $profilingConfigurator;
+
     public function __construct(
         private RoutableMessageBus $routableBus,
         private ContainerInterface $receiverLocator,
@@ -57,8 +62,11 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
         private array $busIds = [],
         private ?ContainerInterface $rateLimiterLocator = null,
         private ?array $signals = null,
+        ?callable $profilingConfigurator = null,
     ) {
         parent::__construct();
+
+        $this->profilingConfigurator = $profilingConfigurator;
     }
 
     protected function configure(): void
@@ -79,6 +87,7 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
                 new InputOption('all', null, InputOption::VALUE_NONE, 'Consume messages from all receivers'),
                 new InputOption('exclude-receivers', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude specific receivers/transports from consumption (can only be used with --all)'),
                 new InputOption('keepalive', null, InputOption::VALUE_OPTIONAL, 'Whether to use the transport\'s keepalive mechanism if implemented', self::DEFAULT_KEEPALIVE_INTERVAL),
+                new InputOption('profile', null, InputOption::VALUE_NONE, 'Collect profiling data for each handled message'),
             ])
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> command consumes messages and dispatches them to the message bus.
@@ -271,6 +280,22 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
         $bus = $input->getOption('bus') ? $this->routableBus->getMessageBus($input->getOption('bus')) : $this->routableBus;
 
         $this->worker = new Worker($receivers, $bus, $this->eventDispatcher, $this->logger, $rateLimiters);
+        $profilingTeardown = null;
+
+        if ($input->getOption('profile')) {
+            if (!\is_callable($this->profilingConfigurator)) {
+                throw new RuntimeException('The "--profile" option requires the Symfony profiler to be enabled.');
+            }
+
+            $result = ($this->profilingConfigurator)($this->worker, $this->eventDispatcher, $input, $output, $io);
+
+            if (!\is_array($result) || !isset($result['worker']) || !$result['worker'] instanceof Worker) {
+                throw new \LogicException('The profiling configurator must return an array with a "worker" key containing a Worker instance.');
+            }
+
+            $this->worker = $result['worker'];
+            $profilingTeardown = \is_callable($result['onStop'] ?? null) ? $result['onStop'] : null;
+        }
         $options = [
             'sleep' => $input->getOption('sleep') * 1000000,
         ];
@@ -281,6 +306,10 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
         try {
             $this->worker->run($options);
         } finally {
+            if (null !== $profilingTeardown) {
+                $profilingTeardown();
+            }
+
             $this->worker = null;
         }
 

--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -26,6 +26,10 @@ use Symfony\Component\VarDumper\Caster\ClassStub;
 class MessengerDataCollector extends DataCollector implements LateDataCollectorInterface
 {
     private array $traceableBuses = [];
+    /**
+     * @var array<int, array{message: object, transport: ?string, ack: ?bool, retry: bool, throwable: ?\Throwable, profile: array<string, mixed>}> 
+     */
+    private array $processedMessages = [];
 
     public function registerBus(string $name, TraceableMessageBus $bus): void
     {
@@ -34,12 +38,33 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
-        // Noop. Everything is collected live by the traceable buses & cloned as late as possible.
+        if ('messenger' === $request->attributes->get('_virtual_type') && $request->attributes->has('messenger.message')) {
+            $message = $request->attributes->get('messenger.message');
+
+            if (!\is_object($message)) {
+                return;
+            }
+
+            $this->processedMessages[] = [
+                'message' => $message,
+                'transport' => $request->attributes->get('messenger.transport'),
+                'ack' => $request->attributes->get('messenger.ack'),
+                'retry' => (bool) $request->attributes->get('messenger.retry'),
+                'throwable' => $request->attributes->get('messenger.throwable'),
+                'profile' => $request->attributes->get('messenger.profile') ?? [],
+            ];
+        }
     }
 
     public function lateCollect(): void
     {
-        $this->data = ['messages' => [], 'buses' => array_keys($this->traceableBuses)];
+        $processedMessages = array_map($this->createProcessedMessage(...), $this->processedMessages);
+
+        $this->data = [
+            'messages' => [],
+            'buses' => array_keys($this->traceableBuses),
+            'processed_messages' => $processedMessages,
+        ];
 
         $messages = [];
         foreach ($this->traceableBuses as $busName => $bus) {
@@ -67,6 +92,8 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
         foreach ($this->traceableBuses as $traceableBus) {
             $traceableBus->reset();
         }
+
+        $this->processedMessages = [];
     }
 
     protected function getCasters(): array
@@ -125,8 +152,69 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
         return array_filter($this->data['messages'], fn ($message) => $bus === $message['bus']);
     }
 
+    public function getProcessedMessages(?bool $ack = null): array
+    {
+        $messages = $this->data['processed_messages'] ?? [];
+
+        if (null === $ack) {
+            return $messages;
+        }
+
+        return array_values(array_filter($messages, static function (array $message) use ($ack): bool {
+            return (bool) $message['ack'] === $ack;
+        }));
+    }
+
     public function getBuses(): array
     {
         return $this->data['buses'];
+    }
+
+    private function createProcessedMessage(array $processed): array
+    {
+        $message = $processed['message'];
+        $profile = $processed['profile'];
+
+        $timeline = [];
+        foreach ($profile['events'] ?? [] as $event) {
+            $timeline[] = [
+                'name' => $event['name'],
+                'category' => $event['category'],
+                'origin' => $event['origin'],
+                'start_time' => $event['start_time'],
+                'end_time' => $event['end_time'],
+                'duration' => $event['duration'],
+                'memory' => $event['memory'],
+            ];
+        }
+
+        $data = [
+            'message' => [
+                'type' => new ClassStub($message::class),
+                'value' => $this->cloneVar($message),
+            ],
+            'transport' => $processed['transport'],
+            'ack' => $processed['ack'],
+            'retry' => $processed['retry'],
+            'duration' => $profile['duration'] ?? null,
+            'memory' => $profile['memory'] ?? null,
+            'origin' => $profile['origin'] ?? null,
+            'start_time' => $profile['start_time'] ?? null,
+            'end_time' => $profile['end_time'] ?? null,
+            'section' => $profile['section'] ?? null,
+            'message_hash' => $profile['message_hash'] ?? null,
+            'timeline' => $timeline,
+        ];
+
+        if ($throwable = $processed['throwable']) {
+            $data['exception'] = [
+                'type' => $throwable::class,
+                'value' => $this->cloneVar($throwable),
+            ];
+        }
+
+        $data['status'] = $processed['ack'] ? 'ack' : ($processed['retry'] ? 'retry' : 'failed');
+
+        return $data;
     }
 }

--- a/src/Symfony/Component/Messenger/Debug/MessageProcessingRequest.php
+++ b/src/Symfony/Component/Messenger/Debug/MessageProcessingRequest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Debug;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Envelope;
+use function spl_object_id;
+
+/**
+ * @internal
+ */
+final class MessageProcessingRequest extends Request
+{
+    private ?bool $ack = null;
+    private bool $willRetry = false;
+    private ?\Throwable $throwable = null;
+    /** @var array<string, mixed>|null */
+    private ?array $messageProfile = null;
+
+    public function __construct(
+        public readonly Envelope $envelope,
+        public readonly string $transport,
+    ) {
+        $message = $envelope->getMessage();
+        $messageHash = spl_object_id($message);
+
+        parent::__construct(
+            attributes: [
+                '_controller' => $message::class,
+                '_virtual_type' => 'messenger',
+                'messenger.transport' => $transport,
+                'messenger.envelope' => $envelope,
+                'messenger.message' => $message,
+                'messenger.message_hash' => $messageHash,
+            ],
+            server: $_SERVER,
+        );
+    }
+
+    public function complete(bool $ack, bool $willRetry, ?\Throwable $throwable = null, ?array $messageProfile = null): void
+    {
+        $this->ack = $ack;
+        $this->willRetry = $willRetry;
+        $this->throwable = $throwable;
+        $this->messageProfile = $messageProfile;
+
+        $this->attributes->set('messenger.ack', $ack);
+        $this->attributes->set('messenger.retry', $willRetry);
+        $this->attributes->set('messenger.throwable', $throwable);
+
+        if ($messageProfile) {
+            $this->attributes->set('messenger.profile', $messageProfile);
+
+            foreach ($messageProfile as $key => $value) {
+                $this->attributes->set('messenger.profile.'.$key, $value);
+            }
+        }
+    }
+
+    public function getUri(): string
+    {
+        return sprintf('%s via %s', $this->envelope->getMessage()::class, $this->transport);
+    }
+
+    public function getMethod(): string
+    {
+        return 'MESSAGE';
+    }
+
+    public function getResponse(): Response
+    {
+        $ack = $this->ack;
+        $willRetry = $this->willRetry;
+
+        return new class($ack, $willRetry) extends Response {
+            public function __construct(private readonly ?bool $ack, private readonly bool $willRetry)
+            {
+                parent::__construct();
+            }
+
+            public function getStatusCode(): int
+            {
+                if (null === $this->ack) {
+                    return Response::HTTP_PROCESSING;
+                }
+
+                if ($this->ack) {
+                    return Response::HTTP_OK;
+                }
+
+                if ($this->willRetry) {
+                    return Response::HTTP_SERVICE_UNAVAILABLE;
+                }
+
+                return Response::HTTP_INTERNAL_SERVER_ERROR;
+            }
+        };
+    }
+
+    public function getClientIp(): string
+    {
+        return 'messenger://'.$this->transport;
+    }
+
+    public function getThrowable(): ?\Throwable
+    {
+        return $this->throwable;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getMessageProfile(): ?array
+    {
+        return $this->messageProfile;
+    }
+}

--- a/src/Symfony/Component/Messenger/EventListener/MessageProfilerListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/MessageProfilerListener.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Contracts\Service\ResetInterface;
+
+use function spl_object_id;
+
+/**
+ * @internal
+ */
+final class MessageProfilerListener implements EventSubscriberInterface, ResetInterface
+{
+    private const STOPWATCH_EVENT = 'messenger.message';
+
+    /**
+     * @var array<int, array{section: string, transport: string, retry: bool, ack: bool|null}>
+     */
+    private array $messages = [];
+
+    /**
+     * @var array<string, array{
+     *     section: string,
+     *     transport: string,
+     *     retry: bool,
+     *     ack: bool,
+     *     message_hash: int,
+     *     duration?: int|float|null,
+     *     memory?: int|null,
+     *     origin?: int|float|null,
+     *     start_time?: int|float|null,
+     *     end_time?: int|float|null,
+     *     events?: array<int, array{
+     *         name: string,
+     *         category: string,
+     *         origin: int|float,
+     *         start_time: int|float,
+     *         end_time: int|float,
+     *         duration: int|float,
+     *         memory: int,
+     *     }>,
+     * }>
+     */
+    private array $profiles = [];
+
+    public function __construct(
+        private readonly Stopwatch $stopwatch,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageReceivedEvent::class => ['onMessageReceived', -2048],
+            WorkerMessageHandledEvent::class => ['onMessageHandled', -2048],
+            WorkerMessageFailedEvent::class => ['onMessageFailed', -2048],
+        ];
+    }
+
+    public function onMessageReceived(WorkerMessageReceivedEvent $event): void
+    {
+        if (!$event->shouldHandle()) {
+            return;
+        }
+
+        $message = $event->getEnvelope()->getMessage();
+        $messageHash = spl_object_id($message);
+
+        if (isset($this->messages[$messageHash])) {
+            return;
+        }
+
+        $sectionId = $this->createSectionId($messageHash);
+
+        $this->stopwatch->openSection($sectionId);
+        $this->stopwatch->start(self::STOPWATCH_EVENT, 'messenger');
+
+        $this->messages[$messageHash] = [
+            'section' => $sectionId,
+            'transport' => $event->getReceiverName(),
+            'retry' => false,
+            'ack' => null,
+        ];
+    }
+
+    public function onMessageHandled(WorkerMessageHandledEvent $event): void
+    {
+        $this->complete($event->getEnvelope()->getMessage(), true, false);
+    }
+
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        $this->complete($event->getEnvelope()->getMessage(), false, $event->willRetry());
+    }
+
+    public function getSectionId(object $message): ?string
+    {
+        return $this->messages[spl_object_id($message)]['section'] ?? null;
+    }
+
+    /**
+     * @return array<string, array{section: string, transport: string, retry: bool, ack: bool, message_hash: int}>
+     */
+    public function getProfiles(): array
+    {
+        return $this->profiles;
+    }
+
+    public function getProfile(string $sectionId): ?array
+    {
+        return $this->profiles[$sectionId] ?? null;
+    }
+
+    public function reset(): void
+    {
+        foreach ($this->messages as $messageHash => $message) {
+            if ($this->stopwatch->isStarted(self::STOPWATCH_EVENT)) {
+                try {
+                    $this->stopwatch->stop(self::STOPWATCH_EVENT);
+                } catch (\LogicException) {
+                    // ignore if the event was not started
+                }
+            }
+
+            try {
+                $this->stopwatch->stopSection($message['section']);
+            } catch (\LogicException) {
+                // ignore if the section was already stopped
+            }
+        }
+
+        $this->messages = [];
+        $this->profiles = [];
+    }
+
+    private function complete(object $message, bool $ack, bool $retry): void
+    {
+        $messageHash = spl_object_id($message);
+
+        if (!isset($this->messages[$messageHash])) {
+            return;
+        }
+
+        $current = $this->messages[$messageHash];
+        unset($this->messages[$messageHash]);
+
+        $event = null;
+        if ($this->stopwatch->isStarted(self::STOPWATCH_EVENT)) {
+            try {
+                $event = $this->stopwatch->stop(self::STOPWATCH_EVENT);
+            } catch (\LogicException) {
+                // ignore if the event was already stopped
+            }
+        }
+
+        try {
+            $this->stopwatch->stopSection($current['section']);
+        } catch (\LogicException) {
+            // ignore if the section was already stopped
+        }
+
+        $sectionEvents = $this->stopwatch->getSectionEvents($current['section']);
+        $primaryEvent = $sectionEvents[self::STOPWATCH_EVENT] ?? $event;
+
+        $events = [];
+        foreach ($sectionEvents as $name => $sectionEvent) {
+            if ('section' === $sectionEvent->getCategory()) {
+                continue;
+            }
+
+            $events[] = [
+                'name' => $name,
+                'category' => $sectionEvent->getCategory(),
+                'origin' => $sectionEvent->getOrigin(),
+                'start_time' => $sectionEvent->getStartTime(),
+                'end_time' => $sectionEvent->getEndTime(),
+                'duration' => $sectionEvent->getDuration(),
+                'memory' => $sectionEvent->getMemory(),
+            ];
+        }
+
+        $this->profiles[$current['section']] = [
+            'section' => $current['section'],
+            'transport' => $current['transport'],
+            'retry' => $retry,
+            'ack' => $ack,
+            'message_hash' => $messageHash,
+            'duration' => $primaryEvent?->getDuration(),
+            'memory' => $primaryEvent?->getMemory(),
+            'origin' => $primaryEvent?->getOrigin(),
+            'start_time' => $primaryEvent?->getStartTime(),
+            'end_time' => $primaryEvent?->getEndTime(),
+            'events' => $events,
+        ];
+    }
+
+    private function createSectionId(int $messageHash): string
+    {
+        return 'messenger.'.$messageHash;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -17,8 +17,12 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Exception\RuntimeException as ConsoleRuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -32,6 +36,7 @@ use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\ResettableDummyReceiver;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Worker;
 
 class ConsumeMessagesCommandTest extends TestCase
 {
@@ -480,5 +485,91 @@ class ConsumeMessagesCommandTest extends TestCase
             '--all' => true,
             '--exclude-receivers' => ['dummy-receiver1', 'dummy-receiver2'],
         ]);
+    }
+
+    public function testProfileOptionRequiresConfigurator(): void
+    {
+        $receiver = $this->createMock(ReceiverInterface::class);
+        $receiver->expects($this->never())->method('get');
+
+        $receiverLocator = new Container();
+        $receiverLocator->set('dummy-receiver', $receiver);
+
+        $bus = $this->createMock(RoutableMessageBus::class);
+
+        $command = new ConsumeMessagesCommand($bus, $receiverLocator, new EventDispatcher());
+
+        $application = new Application();
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
+
+        $tester = new CommandTester($application->get('messenger:consume'));
+
+        $this->expectException(ConsoleRuntimeException::class);
+        $this->expectExceptionMessage('The "--profile" option requires the Symfony profiler to be enabled.');
+
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--profile' => true,
+            '--limit' => 1,
+        ]);
+    }
+
+    public function testProfileOptionConfiguresWorker(): void
+    {
+        $envelope = new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')]);
+
+        $receiver = $this->createMock(ReceiverInterface::class);
+        $receiver->expects($this->once())->method('get')->willReturn([$envelope]);
+
+        $receiverLocator = new Container();
+        $receiverLocator->set('dummy-receiver', $receiver);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch');
+
+        $busLocator = new Container();
+        $busLocator->set('dummy-bus', $bus);
+
+        $dispatcher = new EventDispatcher();
+
+        $configureCalls = 0;
+        $teardownCalls = 0;
+
+        $profilingConfigurator = function (Worker $worker, EventDispatcherInterface $eventDispatcher, InputInterface $input, OutputInterface $output, SymfonyStyle $io) use (&$configureCalls, &$teardownCalls, $dispatcher) {
+            ++$configureCalls;
+            $this->assertSame($dispatcher, $eventDispatcher);
+            $this->assertInstanceOf(SymfonyStyle::class, $io);
+
+            return [
+                'worker' => $worker,
+                'onStop' => function () use (&$teardownCalls) {
+                    ++$teardownCalls;
+                },
+            ];
+        };
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus($busLocator), $receiverLocator, $dispatcher, profilingConfigurator: $profilingConfigurator);
+
+        $application = new Application();
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            $application->add($command);
+        }
+
+        $tester = new CommandTester($application->get('messenger:consume'));
+        $tester->execute([
+            'receivers' => ['dummy-receiver'],
+            '--profile' => true,
+            '--limit' => 1,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertSame(1, $configureCalls);
+        $this->assertSame(1, $teardownCalls);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Messenger\Tests\DataCollector;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -164,6 +166,48 @@ class MessengerDataCollectorTest extends TestCase
 
         $this->assertSame('#5', $messages[4]['message']['value']['message']);
         $this->assertSame('second bus', $messages[4]['bus']);
+    }
+
+    public function testCollectsProcessedMessages(): void
+    {
+        $collector = new MessengerDataCollector();
+
+        $request = new Request();
+        $message = new DummyMessage('processed');
+        $request->attributes->set('_virtual_type', 'messenger');
+        $request->attributes->set('messenger.transport', 'async');
+        $request->attributes->set('messenger.message', $message);
+        $request->attributes->set('messenger.ack', true);
+        $request->attributes->set('messenger.retry', false);
+        $request->attributes->set('messenger.profile', [
+            'duration' => 12.5,
+            'memory' => 2048,
+            'events' => [[
+                'name' => 'messenger.message',
+                'category' => 'messenger',
+                'origin' => 0.0,
+                'start_time' => 0.0,
+                'end_time' => 12.5,
+                'duration' => 12.5,
+                'memory' => 2048,
+            ]],
+        ]);
+
+        $collector->collect($request, new Response());
+        $collector->lateCollect();
+
+        $processed = $collector->getProcessedMessages();
+
+        $this->assertCount(1, $processed);
+        $messageData = $processed[0];
+        $this->assertSame('async', $messageData['transport']);
+        $this->assertTrue($messageData['ack']);
+        $this->assertSame(12.5, $messageData['duration']);
+        $this->assertSame(2048, $messageData['memory']);
+        $this->assertSame('ack', $messageData['status']);
+        $this->assertInstanceOf(Data::class, $messageData['message']['value']);
+        $this->assertArrayHasKey(0, $messageData['timeline']);
+        $this->assertSame('messenger.message', $messageData['timeline'][0]['name']);
     }
 
     private function getDataAsString(Data $data): string

--- a/src/Symfony/Component/Messenger/Tests/EventListener/MessageProfilerListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/MessageProfilerListenerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\EventListener\MessageProfilerListener;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+use function spl_object_id;
+
+class MessageProfilerListenerTest extends TestCase
+{
+    public function testProfilesHandledMessage(): void
+    {
+        $stopwatch = new Stopwatch(true);
+        $listener = new MessageProfilerListener($stopwatch);
+
+        $message = new DummyMessage('body');
+        $envelope = new Envelope($message);
+
+        $listener->onMessageReceived(new WorkerMessageReceivedEvent($envelope, 'async'));
+
+        $sectionId = $listener->getSectionId($message);
+        $this->assertNotNull($sectionId);
+
+        $listener->onMessageHandled(new WorkerMessageHandledEvent($envelope, 'async'));
+
+        $profiles = $listener->getProfiles();
+        $this->assertArrayHasKey($sectionId, $profiles);
+        $profile = $profiles[$sectionId];
+        $this->assertSame($sectionId, $profile['section']);
+        $this->assertSame('async', $profile['transport']);
+        $this->assertTrue($profile['ack']);
+        $this->assertFalse($profile['retry']);
+        $this->assertSame(spl_object_id($message), $profile['message_hash']);
+        $this->assertIsArray($profile['events']);
+        $this->assertNotEmpty($profile['events']);
+        $this->assertArrayHasKey('duration', $profile);
+        $this->assertArrayHasKey('memory', $profile);
+
+        $events = $stopwatch->getSectionEvents($sectionId);
+        $this->assertArrayHasKey('messenger.message', $events);
+        $this->assertGreaterThanOrEqual(0, $events['messenger.message']->getDuration());
+        $this->assertSame($events['messenger.message']->getDuration(), $profile['duration']);
+    }
+
+    public function testProfilesFailedMessageWithRetry(): void
+    {
+        $stopwatch = new Stopwatch(true);
+        $listener = new MessageProfilerListener($stopwatch);
+
+        $message = new DummyMessage('body');
+        $envelope = new Envelope($message);
+
+        $listener->onMessageReceived(new WorkerMessageReceivedEvent($envelope, 'failed'));
+
+        $failedEvent = new WorkerMessageFailedEvent($envelope, 'failed', new \RuntimeException('Boom'));
+        $failedEvent->setForRetry();
+
+        $listener->onMessageFailed($failedEvent);
+
+        $profiles = $listener->getProfiles();
+        $this->assertCount(1, $profiles);
+        $profile = reset($profiles);
+        $this->assertFalse($profile['ack']);
+        $this->assertTrue($profile['retry']);
+        $this->assertSame('failed', $profile['transport']);
+    }
+
+    public function testDoesNotStartSectionWhenMessageShouldNotBeHandled(): void
+    {
+        $stopwatch = new Stopwatch(true);
+        $listener = new MessageProfilerListener($stopwatch);
+
+        $message = new DummyMessage('body');
+        $envelope = new Envelope($message);
+        $event = new WorkerMessageReceivedEvent($envelope, 'async');
+        $event->shouldHandle(false);
+
+        $listener->onMessageReceived($event);
+
+        $this->assertNull($listener->getSectionId($message));
+        $this->assertSame([], $listener->getProfiles());
+    }
+}


### PR DESCRIPTION
## Summary
- add a `--profile` flag to `messenger:consume` that delegates to a configurator for enabling worker profiling and teardown handling
- expose saved profiles from `MessengerProfilerListener`, register the new configurator service, and print profile links for handled messages
- cover the new option with command tests verifying configurator requirements and execution hooks

## Testing
- `php -l src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php`
- `php -l src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php`
- `php -l src/Symfony/Bundle/FrameworkBundle/EventListener/MessengerProfilerListener.php`
- `php -l src/Symfony/Bundle/FrameworkBundle/Messenger/ConsumeMessagesCommandProfiler.php`
- `php -l src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger_debug.php`
- `php -l src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php`
- `./phpunit src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php` *(fails: simple-phpunit bridge not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e02c77eb548322b3f930d5b7753c36